### PR TITLE
refactor: use 'number' instead of 'string' in data objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ activitiesRunningInstances.forEach((value, key) => {
   }
 });
 
-// add CSS classes to waiting edge instances
+// add Overlays on waiting edge instances
 edgesWaitingInstances.forEach((value, key) => {
   if (value.critical) {
     bpmnVisualization.bpmnElementsRegistry.addOverlays(key, [

--- a/src/index.js
+++ b/src/index.js
@@ -36,10 +36,10 @@ const edgesWaitingInstances = getEdgesWaitingInstances();
 // add Overlays on running activity instances
 activitiesRunningInstances.forEach((value, key) => {
   // running on time
-  if (value.onTime != false) {
+  if (value.onTime) {
     bpmnVisualization.bpmnElementsRegistry.addOverlays(key, {
       position: "top-center",
-      label: value.onTime,
+      label: String(value.onTime),
       style: {
         font: { color: "white", size: 16 },
         fill: { color: "green", opacity: 50 },
@@ -48,10 +48,10 @@ activitiesRunningInstances.forEach((value, key) => {
     });
   }
   // running late with risky level
-  if (value.risky != false) {
+  if (value.risky) {
     bpmnVisualization.bpmnElementsRegistry.addOverlays(key, {
       position: "top-left",
-      label: value.risky,
+      label: String(value.risky),
       style: {
         font: { color: "white", size: 16 },
         fill: { color: "#FF8C00", opacity: 50 },
@@ -60,10 +60,10 @@ activitiesRunningInstances.forEach((value, key) => {
     });
   }
   // running late with critical level
-  if (value.critical != false) {
+  if (value.critical) {
     bpmnVisualization.bpmnElementsRegistry.addOverlays(key, {
       position: "top-right",
-      label: value.critical,
+      label: String(value.critical),
       style: {
         font: { color: "white", size: 16 },
         fill: { color: "red", opacity: 50 },
@@ -75,45 +75,79 @@ activitiesRunningInstances.forEach((value, key) => {
 
 // add CSS classes to running activity instances
 activitiesRunningInstances.forEach((value, key) => {
-  if (value.critical != false){
+  if (value.critical){
       bpmnVisualization.bpmnElementsRegistry.addCssClasses(key, "task-running-critical");
   }
-  else if (value.risky != false){
+  else if (value.risky){
       bpmnVisualization.bpmnElementsRegistry.addCssClasses(key, "task-running-risky");
   }
-  else if (value.onTime != false){
+  else if (value.onTime){
     bpmnVisualization.bpmnElementsRegistry.addCssClasses(key, "task-running-on-time");
   }
 });
 
-// add Overlays on waiting edge instances
+// add CSS classes to waiting edge instances
 edgesWaitingInstances.forEach((value, key) => {
-  bpmnVisualization.bpmnElementsRegistry.addOverlays(key, {
-    position: "middle",
-    label: value,
-    style: {
-      font: { color: "black", size: 16 },
-      fill: { color: "red", opacity: 50 },
-      stroke: { color: "red", width: 2 }
-    }
-  });
+  if (value.critical) {
+    bpmnVisualization.bpmnElementsRegistry.addOverlays(key, [
+      {
+        position: "middle",
+        label: String(value.critical),
+        style: {
+          font: { color: "black", size: 16 },
+          fill: { color: "red", opacity: 50 },
+          stroke: { color: "red", width: 2 }
+        }
+      }
+    ]);
+  } else if(value.risky){
+    bpmnVisualization.bpmnElementsRegistry.addOverlays(key, [
+      {
+        position: "middle",
+        label: String(value.risky),
+        style: {
+          font: { color: "white", size: 16 },
+          fill: { color: "green", opacity: 50 },
+          stroke: { color: "green", width: 2 }
+        }
+      }
+    ]);
+  }
+  else if(value.onTime){
+    bpmnVisualization.bpmnElementsRegistry.addOverlays(key, [
+      {
+        position: "middle",
+        label: String(value.onTime),
+        style: {
+          font: { color: "black", size: 16 },
+          fill: { color: "#FF8C00", opacity: 50 },
+          stroke: { color: "#FF8C00", width: 2 }
+        }
+      }
+    ]);
+  }
 });
 
 // add CSS classes to waiting edge instances
 edgesWaitingInstances.forEach((value, key) => {
-  bpmnVisualization.bpmnElementsRegistry.addCssClasses(key, "path-waiting");
-});
+  if (value.critical){
+    bpmnVisualization.bpmnElementsRegistry.addCssClasses(key, "path-waiting-critical");
+  } else if (value.risky){
+    bpmnVisualization.bpmnElementsRegistry.addCssClasses(key, "path-waiting-risky");
+  } else if (value.onTime){
+    bpmnVisualization.bpmnElementsRegistry.addCssClasses(key, "path-waiting-on-time");
+  }
 
 /**
  * @returns {Map<string, Object>} key: BPMN element id / value: running instances
  */
 function getActivitiesRunningInstances() {
   return new Map([
-    ["assignApprover", {"onTime": "5", "risky": "0", "critical": "0"}],
-    ["approveInvoice", {"onTime": "2", "risky": "3", "critical": "0"}],
-    ["reviewInvoice", {"onTime": "4", "risky": "1", "critical": "2"}],
-    ["prepareBankTransfer", {"onTime": "0", "risky": "0", "critical": "0"}],
-    ["archiveInvoice", {"onTime": "0", "risky": "0", "critical": "0"}],
+    ["assignApprover", {"onTime": 5, "risky": 0, "critical": 0}],
+    ["approveInvoice", {"onTime": 2, "risky": 3, "critical": 0}],
+    ["reviewInvoice", {"onTime": 4, "risky": 1, "critical": 2}],
+    ["prepareBankTransfer", {"onTime": 0, "risky": "0", "critical": 0}],
+    ["archiveInvoice", {"onTime": 0, "risky": 0, "critical": 0}],
   ]);
 }
 
@@ -122,6 +156,6 @@ function getActivitiesRunningInstances() {
  */
 function getEdgesWaitingInstances() {
   return new Map([
-    ["invoiceApproved", "2"],
+    ["invoiceApproved", {"onTime": 0, "risky": 0, "critical": 2}],
   ]);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -88,55 +88,21 @@ activitiesRunningInstances.forEach((value, key) => {
 
 // add Overlays on waiting edge instances
 edgesWaitingInstances.forEach((value, key) => {
-  if (value.critical) {
-    bpmnVisualization.bpmnElementsRegistry.addOverlays(key, [
-      {
-        position: "middle",
-        label: `${value.critical}`,
-        style: {
-          font: { color: "black", size: 16 },
-          fill: { color: "red", opacity: 50 },
-          stroke: { color: "red", width: 2 }
-        }
-      }
-    ]);
-  } else if(value.risky){
-    bpmnVisualization.bpmnElementsRegistry.addOverlays(key, [
-      {
-        position: "middle",
-        label: `${value.risky}`,
-        style: {
-          font: { color: "white", size: 16 },
-          fill: { color: "green", opacity: 50 },
-          stroke: { color: "green", width: 2 }
-        }
-      }
-    ]);
-  }
-  else if(value.onTime){
-    bpmnVisualization.bpmnElementsRegistry.addOverlays(key, [
-      {
-        position: "middle",
-        label: `${value.onTime}`,
-        style: {
-          font: { color: "black", size: 16 },
-          fill: { color: "#FF8C00", opacity: 50 },
-          stroke: { color: "#FF8C00", width: 2 }
-        }
-      }
-    ]);
-  }
+  bpmnVisualization.bpmnElementsRegistry.addOverlays(key, {
+    position: "middle",
+    label: `${value}`,
+    style: {
+      font: { color: "black", size: 16 },
+      fill: { color: "red", opacity: 50 },
+      stroke: { color: "red", width: 2 }
+    }
+  });
 });
 
 // add CSS classes to waiting edge instances
 edgesWaitingInstances.forEach((value, key) => {
-  if (value.critical){
-    bpmnVisualization.bpmnElementsRegistry.addCssClasses(key, "path-waiting-critical");
-  } else if (value.risky){
-    bpmnVisualization.bpmnElementsRegistry.addCssClasses(key, "path-waiting-risky");
-  } else if (value.onTime){
-    bpmnVisualization.bpmnElementsRegistry.addCssClasses(key, "path-waiting-on-time");
-  }
+  bpmnVisualization.bpmnElementsRegistry.addCssClasses(key, "path-waiting");
+});
 
 /**
  * @returns {Map<string, Object>} key: BPMN element id / value: running instances
@@ -156,6 +122,6 @@ function getActivitiesRunningInstances() {
  */
 function getEdgesWaitingInstances() {
   return new Map([
-    ["invoiceApproved", {"onTime": 0, "risky": 0, "critical": 2}],
+    ["invoiceApproved", 2],
   ]);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ activitiesRunningInstances.forEach((value, key) => {
   if (value.onTime) {
     bpmnVisualization.bpmnElementsRegistry.addOverlays(key, {
       position: "top-center",
-      label: String(value.onTime),
+      label: `${value.onTime}`,
       style: {
         font: { color: "white", size: 16 },
         fill: { color: "green", opacity: 50 },
@@ -51,7 +51,7 @@ activitiesRunningInstances.forEach((value, key) => {
   if (value.risky) {
     bpmnVisualization.bpmnElementsRegistry.addOverlays(key, {
       position: "top-left",
-      label: String(value.risky),
+      label: `${value.risky}`,
       style: {
         font: { color: "white", size: 16 },
         fill: { color: "#FF8C00", opacity: 50 },
@@ -63,7 +63,7 @@ activitiesRunningInstances.forEach((value, key) => {
   if (value.critical) {
     bpmnVisualization.bpmnElementsRegistry.addOverlays(key, {
       position: "top-right",
-      label: String(value.critical),
+      label: `${value.critical}`,
       style: {
         font: { color: "white", size: 16 },
         fill: { color: "red", opacity: 50 },
@@ -92,7 +92,7 @@ edgesWaitingInstances.forEach((value, key) => {
     bpmnVisualization.bpmnElementsRegistry.addOverlays(key, [
       {
         position: "middle",
-        label: String(value.critical),
+        label: `${value.critical}`,
         style: {
           font: { color: "black", size: 16 },
           fill: { color: "red", opacity: 50 },
@@ -104,7 +104,7 @@ edgesWaitingInstances.forEach((value, key) => {
     bpmnVisualization.bpmnElementsRegistry.addOverlays(key, [
       {
         position: "middle",
-        label: String(value.risky),
+        label: `${value.risky}`,
         style: {
           font: { color: "white", size: 16 },
           fill: { color: "green", opacity: 50 },
@@ -117,7 +117,7 @@ edgesWaitingInstances.forEach((value, key) => {
     bpmnVisualization.bpmnElementsRegistry.addOverlays(key, [
       {
         position: "middle",
-        label: String(value.onTime),
+        label: `${value.onTime}`,
         style: {
           font: { color: "black", size: 16 },
           fill: { color: "#FF8C00", opacity: 50 },


### PR DESCRIPTION
The related data is actually a number, so the objects should reflect this.

### Notes

The value passed as overlay label property is transformed into a String. This is a current limitation of bpmn-visualization.
If the transform is not done, an error occurs. I will fill an issue in the bpmn-visualization repository. The label type is string in the API types but nothing prevents the JavaScript code to pass a number.

In the following stack trace build.js is the mxGraph code!
```
Uncaught TypeError: str.split is not a function
    plainText build.js:20625
    text build.js:20472
    paint build.js:26794
    redrawShape build.js:22994
    redraw build.js:22831
    redraw build.js:26853
    redrawCellOverlays build.js:50100
    visit build.js:1432
    redrawCellOverlays build.js:50074
    redraw build.js:50319
    addCellOverlay build.js:57438
    addOverlays bpmn-visualization.esm.js:5467
    addOverlays bpmn-visualization.esm.js:5465
    addOverlays bpmn-visualization.esm.js:5794
```